### PR TITLE
Bulgarian localizations available for Bugzilla 4.4.13 and 5.0.4

### DIFF
--- a/download/index.html
+++ b/download/index.html
@@ -92,8 +92,8 @@ the maintainer of the particular localization.</p>
     <td>
       <a href="ftp://sotirov-bg.net/pub/contrib/mozilla/bugzilla/l10n/">Български език / Bulgarian</a>
     </td>
-    <td>4.4.12</td>
-    <td>5.0.3</td>
+    <td>4.4.13</td>
+    <td>5.0.4</td>
     <td>&nbsp;</td>
     <td>Георги Д. Сотиров (Georgi D. Sotirov)</td>
   </tr>


### PR DESCRIPTION
Available since 17.02, but better update the page later than never :-)