### PR TITLE
Fix broken links on the Installation List

### DIFF
--- a/installation-list/index.html
+++ b/installation-list/index.html
@@ -49,12 +49,12 @@ the sense defined above, and you would like to be listed, please mail
 
 {% for item in site.data.installation-list %}
   {% if item.orgurl %}
-      <a href="{{ item.orgurl | url_encode }}">{{ item.name }}</a>
+      <a href="{{ item.orgurl }}">{{ item.name }}</a>
   {% else %}
       {{ item.name }}
   {% endif %}
   {% if item.bzurl %}
-        (<a href="{{ item.bzurl | url_encode }}">Bugzilla</a>)
+        (<a href="{{ item.bzurl }}">Bugzilla</a>)
   {% endif %}
   <br>
 {% endfor %}


### PR DESCRIPTION
The external links on the [Installation List](https://www.bugzilla.org/installation-list/) page are broken now. Remove the unnecessary `url_encode` filter to fix the issue.