### PR TITLE
A proper home for the (updated) history content

### DIFF
--- a/about/index.html
+++ b/about/index.html
@@ -36,3 +36,36 @@ for you to use it. However, installation is not complex.</p>
 	<li>Trusted by <a href="../installation-list/">world leaders in technology</a></li>
 	<li>Installable on <a ref="../requirements/">many operating systems</a>, including Windows, Mac and Linux</li>
 </ul>
+
+<h2>A Brief History of Bugzilla</h2>
+
+<p>When mozilla.org first came online in 1998, one of the first products that
+was released was Bugzilla, a bug system implemented using freely available open
+source tools.  Bugzilla was originally written in
+<a href="http://www.tcl.tk/scripting/">TCL</a> by Terry Weissman for use at
+mozilla.org to replace the in-house system then in use at Netscape.  The
+initial installation of Bugzilla was deployed to the public on a mozilla.org
+server on
+<a href="https://www-archive.mozilla.org/news.html#p17" target="_blank">April 6, 1998</a>.</p>
+<p>After a few months of testing and fixing on a public deployment,
+Bugzilla was finally released as open source via anonymous CVS and available
+for others to use on
+<a href="https://www-archive.mozilla.org/news.html#p44" target="_blank">August 26, 1998</a>.
+At this point. Terry decided to port Bugzilla to
+<a href="http://www.perl.org">Perl</a>, with the hopes that more people would be
+able to contribute to it, since Perl seemed to be a more popular language.
+The completion of the port to Perl was announced on
+<a href="https://www-archive.mozilla.org/news.html#p51" target="_blank">September 15, 1998</a>,
+and committed to CVS 
+<a href="https://github.com/bugzilla/bugzilla/commit/4727e6c09f88e63f02e6c8f359862d0c0942ed36" target="_blank">the following day</a>.</p>
+<p>After a few days of bake time, this was released as Bugzilla 2.0 on
+September 19, 1998.  Since then a large number of projects, both commercial and free
+have adapted it as their primary method of tracking software defects.  In April
+of 2000, Terry handed off control of the Bugzilla project to Tara Hernandez.
+Under Tara's leadership, some of the regular contributors were coerced into
+taking more responsibility, and Bugzilla began to truly become a group effort.
+In July of 2001, facing lots of distraction from her "real job," Tara handed
+off control to Dave Miller, who is still in charge as of this writing.</p>
+
+<p>Additional release history after version 2.0 can be viewed on the
+<a href="/releases/">releases</a> page.</p>

--- a/about/index.html
+++ b/about/index.html
@@ -57,7 +57,7 @@ able to contribute to it, since Perl seemed to be a more popular language.
 The completion of the port to Perl was announced on
 <a href="https://www-archive.mozilla.org/news.html#p51" target="_blank">September 15, 1998</a>,
 and committed to CVS 
-<a href="https://github.com/bugzilla/bugzilla/commit/4727e6c09f88e63f02e6c8f359862d0c0942ed36" target="_blank">the following day</a>.</p>
+<a href="https://github.com/bugzilla/bugzilla/commit/4727e6c09f88e63f02e6c8f359862d0c0942ed36" target="_blank">later that night</a>.</p>
 <p>After a few days of bake time, this was released as Bugzilla 2.0 on
 September 19, 1998.  Since then a large number of projects, both commercial and free
 have adapted it as their primary method of tracking software defects.  In April


### PR DESCRIPTION
I revived the history section off the old Roadmap page, and updated some of it to reflect reality (some of it was wrong) based on a review of historical Mozilla documents with the help of Asa Dotzler. It links to source references where available (old Mozilla press releases, commit logs, etc).  Also putting it in a more appropriate place (the About page).