### PR TITLE
installations-list: Novell bugzilla is better known as SUSE.

### DIFF
--- a/installation-list/index.html
+++ b/installation-list/index.html
@@ -25,6 +25,7 @@ title: "Installation List"
 <li>Red Hat: <a href="https://bugzilla.redhat.com/">https://bugzilla.redhat.com/</a></li>
 <li>Gentoo: <a href="http://bugs.gentoo.org/">http://bugs.gentoo.org/</a></li>
 <li>Novell: <a href="https://bugzilla.novell.com/">https://bugzilla.novell.com/</a></li>
+<li>SUSE/openSUSE: <a href="https://bugzilla.suse.com/">https://bugzilla.suse.com/</a></li>
 </ul>
 
 <h2>Full List</h2>


### PR DESCRIPTION
At the moment bugzilla.novell.com and bugzilla.suse.com are the same
instance. But I think SUSE is more "famous"...
