### PR TITLE
Replace some dead links with their living counterparts

### DIFF
--- a/developers/index.html
+++ b/developers/index.html
@@ -18,7 +18,7 @@ title: "Developers"
     <!-- li><a href="http://www.ravenbrook.com/project/p4dti/tool/cgi/bugzilla-schema/"
          >Database Schema Documentation</a></li -->
     <!-- Should point to master API, but its doc doesn't compile due to Perl 5.14 missing in RHEL6. -->
-    <li><a href="../docs/5.0/en/html/api/">The Bugzilla API Documentation</a></li>
+    <li><a href="https://bugzilla.readthedocs.io/en/latest/api/">The Bugzilla API Documentation</a></li>
     <li><a href="reporting_bugs.html">How to Report a Bug</a></li>
 
 </ul>
@@ -27,8 +27,8 @@ title: "Developers"
 <ul>
     <li><a href="https://dev.mysql.com/doc/">MySQL</a></li>
     <li><a href="http://www.postgresql.org/docs/">PostgreSQL</a></li>
-    <li><a href="http://www.oracle.com/technology/documentation/database.html">Oracle</a></li>
-    <li><a href="http://savage.net.au/SQL/">ANSI SQL</a>
+    <li><a href="https://web.archive.org/web/20100304144431/http://www.oracle.com/technology/documentation/database.html">Oracle</a></li> 
+    <li><a href="https://github.com/ronsavage/SQL">ANSI SQL</a>
         (Bugzilla attempts to conform to SQL-99, when possible).</li>
 </ul>
 

--- a/developers/index.html
+++ b/developers/index.html
@@ -27,7 +27,7 @@ title: "Developers"
 <ul>
     <li><a href="https://dev.mysql.com/doc/">MySQL</a></li>
     <li><a href="http://www.postgresql.org/docs/">PostgreSQL</a></li>
-    <li><a href="https://web.archive.org/web/20100304144431/http://www.oracle.com/technology/documentation/database.html">Oracle</a></li> 
+    <li><a href="https://www.oracle.com/database/technologies/appdev/sql.html">Oracle</a></li> 
     <li><a href="https://ronsavage.github.io/SQL/">ANSI SQL</a>
         (Bugzilla attempts to conform to SQL-99, when possible).</li>
 </ul>

--- a/developers/index.html
+++ b/developers/index.html
@@ -28,7 +28,7 @@ title: "Developers"
     <li><a href="https://dev.mysql.com/doc/">MySQL</a></li>
     <li><a href="http://www.postgresql.org/docs/">PostgreSQL</a></li>
     <li><a href="https://web.archive.org/web/20100304144431/http://www.oracle.com/technology/documentation/database.html">Oracle</a></li> 
-    <li><a href="https://github.com/ronsavage/SQL">ANSI SQL</a>
+    <li><a href="https://ronsavage.github.io/SQL/">ANSI SQL</a>
         (Bugzilla attempts to conform to SQL-99, when possible).</li>
 </ul>
 


### PR DESCRIPTION
- the oracle sql page disappeared in ~2007 according to webarchive
- the savage.net one is just a page pointing the reader to github, so I cut out the middle-man 
- the api docs link just 404'ed, so I pointed it at the docs for the latest version of the rest api 