### PR TITLE
Update installation-list.csv

### DIFF
--- a/_data/installation-list.csv
+++ b/_data/installation-list.csv
@@ -44,7 +44,6 @@
 "Geant4 project","http://geant4.org/","http://bugzilla-geant4.kek.jp/"
 "Gentoo","http://www.gentoo.org/","http://bugs.gentoo.org/"
 "Glub Tech, Inc","http://www.glub.com/","http://www.glub.com/bugs/"
-"GNOME","http://www.gnome.org/","http://bugzilla.gnome.org/"
 "Greytip Software Pvt. Ltd.","http://www.greytip.com/","http://bugs.greytip.com/"
 "HPCalc","http://www.hpcalc.org","http://bugs.hpcalc.org"
 "HylaFAX","http://www.hylafax.org/","http://bugs.hylafax.org/bugzilla/"


### PR DESCRIPTION
The Gnome bugzilla page now shows the following message:
After an evaluation (https://wiki.gnome.org/Initiatives/DevelopmentInfrastructure), GNOME has moved from Bugzilla to GitLab. Learn more about GitLab.
No new issues can be reported in GNOME Bugzilla anymore.
To report an issue in a GNOME project, go to GNOME GitLab.