### PR TITLE
Remove reference to Camino

### DIFF
--- a/contributing/reporting_bugs.md
+++ b/contributing/reporting_bugs.md
@@ -6,7 +6,7 @@ redirect_from:
 ---
 
 <span>{% include icons/warning.svg %} If the bug you wish to report affects
-**Mozilla**, **Firefox**, **Thunderbird**, **Camino**, or **Seamonkey**,
+**Mozilla**, **Firefox**, **Thunderbird**, or **Seamonkey**,
 you need to go to **<https://bugzilla.mozilla.org/>**.
 {:.warning}
 


### PR DESCRIPTION
Before this change, contributing/reporting_bugs.html would tell users to report Camino bugs to <https://bugzilla.mozilla.org/>. [Camino hasn’t been maintained since 2013.][1] Camino bugs shouldn’t be reported anywhere.

[1]: <https://caminobrowser.org/blog/>