### PR TITLE
add jekyll-include-cache on the website repository

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -26,6 +26,7 @@ list_bugs: https://bugzilla.mozilla.org/buglist.cgi?product=Bugzilla
 report_bug: https://bugzilla.mozilla.org/enter_bug.cgi?product=Bugzilla
 remote_theme: bugzilla/jekyll-theme
 plugins:
+  - jekyll-include-cache
   - jekyll-redirect-from
   - jekyll-sitemap
 
@@ -100,7 +101,6 @@ defaults:
       breadcrumbs:
       - name: About
         link: /about/
-      
 
 paginate: 10
 paginate_path: "/blog/page/:num/"


### PR DESCRIPTION
This patch enable build caching and depends on https://github.com/bugzilla/jekyll-theme/pull/14.