### PR TITLE
Add missing jekyll-paginate dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,9 +5,10 @@ gem "jekyll", "~> 4.4.1"
 # If you have any plugins, put them here!
 group :jekyll_plugins do
   gem "jekyll-feed", "~> 0.12"
-  gem 'jekyll-sitemap', '~> 1.4'
   gem 'jekyll-include-cache', '~> 0.2.1'
+  gem 'jekyll-paginate', '~> 1.1'
   gem 'jekyll-redirect-from', '~> 0.16.0'
+  gem 'jekyll-sitemap', '~> 1.4'
 end
 
 # Windows and JRuby does not include zoneinfo files, so bundle the tzinfo-data

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -88,6 +88,7 @@ GEM
       jekyll (>= 3.7, < 5.0)
     jekyll-include-cache (0.2.1)
       jekyll (>= 3.7, < 5.0)
+    jekyll-paginate (1.1.0)
     jekyll-redirect-from (0.16.0)
       jekyll (>= 3.3, < 5.0)
     jekyll-sass-converter (3.1.0)
@@ -181,6 +182,7 @@ DEPENDENCIES
   jekyll (~> 4.4.1)
   jekyll-feed (~> 0.12)
   jekyll-include-cache (~> 0.2.1)
+  jekyll-paginate (~> 1.1)
   jekyll-redirect-from (~> 0.16.0)
   jekyll-sitemap (~> 1.4)
   jekyll-theme-bugzilla!

--- a/_config.yml
+++ b/_config.yml
@@ -12,6 +12,7 @@ report_bug: https://bugzilla.mozilla.org/enter_bug.cgi?product=Bugzilla
 theme: jekyll-theme-bugzilla
 plugins:
   - jekyll-include-cache
+  - jekyll-paginate
   - jekyll-redirect-from
   - jekyll-sitemap
 


### PR DESCRIPTION
We need to explicitly call jekyll-paginate in _config.yml now. If we don't the list of posts isn't generated on bugzilla.org/blog page.